### PR TITLE
finder: remove now-useless guard

### DIFF
--- a/pkg/finder/finder.go
+++ b/pkg/finder/finder.go
@@ -382,9 +382,7 @@ func (f *criFinder) Scan() ([]PodResources, error) {
 				continue
 			}
 			contRes.Resources = append(contRes.Resources, makeCPUResource(cpuList)...)
-			if ci.Config != nil && ci.Config.Envs != nil {
-				contRes.Resources = append(contRes.Resources, makePCIDeviceResource(env, f.pci2ResourceMap)...)
-			}
+			contRes.Resources = append(contRes.Resources, makePCIDeviceResource(env, f.pci2ResourceMap)...)
 
 			log.Printf("pod %q container %q contData=%s\n", podSb.Metadata.Name, ContStatusResp.Status.Metadata.Name, spew.Sdump(contRes))
 			podRes.Containers = append(podRes.Containers, contRes)


### PR DESCRIPTION
When working at the very beginning of the crio support
we added this guard to prevent crashes; later on we
fixed the env vars detection to work seamlessly with crio
and containerd (no need to explicitly be told which runtime we
are working with).

Due to an oversight, the guard was not removed, preventing
the device accounting to work at all under crio.

Just removing the guard let the device accounting work as
expected.

Signed-off-by: Francesco Romani <fromani@redhat.com>