### PR TITLE
Updates due to change of NodeResourceTopology CRD APIGroup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,17 +15,16 @@ require (
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1
 	github.com/opencontainers/runtime-spec v1.0.0
-	github.com/swatisehgal/topologyapi v0.0.0-20200701120235-74ecc412df7b
+	github.com/swatisehgal/topologyapi v0.0.0-20200802230855-6f9c5ac0d357
 	golang.org/x/text v0.3.3 // indirect
 	google.golang.org/grpc v1.28.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	k8s.io/api v0.18.6
 	k8s.io/apimachinery v0.18.6
-	k8s.io/client-go v0.18.6
+	k8s.io/client-go v11.0.0+incompatible
 	k8s.io/cri-api v0.0.0
 	k8s.io/kubelet v0.18.1
 	k8s.io/kubernetes v1.18.6
-	k8s.io/utils v0.0.0-20200603063816-c1c6865ac451 // indirect
 )
 
 // Pinned to kubernetes-1.18.6

--- a/go.sum
+++ b/go.sum
@@ -542,6 +542,8 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/swatisehgal/topologyapi v0.0.0-20200701120235-74ecc412df7b h1:wTT+TDqHq18oVrja1t3bS/6yf1dPcuiFC6MR6YI56hk=
 github.com/swatisehgal/topologyapi v0.0.0-20200701120235-74ecc412df7b/go.mod h1:+tS4qfBJN6fLzdcNaVHSvbFThaNxMa44e1NU7T0WlnE=
+github.com/swatisehgal/topologyapi v0.0.0-20200802230855-6f9c5ac0d357 h1:cI79HNM0iOTzNjo/ToVFUUarjhuUTD00aenpgWcxs+k=
+github.com/swatisehgal/topologyapi v0.0.0-20200802230855-6f9c5ac0d357/go.mod h1:9CKMMS83d72bYp2AIc7VSV9acET7rHyBFAnUvdISijI=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/thecodeteam/goscaleio v0.1.0/go.mod h1:68sdkZAsK8bvEwBlbQnlLS+xU+hvLYM/iQ8KXej1AwM=
@@ -648,6 +650,8 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:TzXSXBo42m9gQenoE3b9BGiEpg5IG2JkU5FkPIawgtw=
+golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/perf v0.0.0-20180704124530-6e6d33e29852/go.mod h1:JLpeXjPJfIyPr5TlbXLkXWLhP8nz10XfvxElABhCtcw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -696,6 +700,8 @@ golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e h1:EHBhcS0mlXEAVwNyO2dLfjToGsyY4j24pTs2ScHnX7s=
+golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20170915040203-e531a2a1c15f/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -851,6 +857,8 @@ k8s.io/system-validators v1.0.4/go.mod h1:HgSgTg4NAGNoYYjKsUyk52gdNi2PVDswQ9Iyn6
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200603063816-c1c6865ac451 h1:v8ud2Up6QK1lNOKFgiIVrZdMg7MpmSnvtrOieolJKoE=
 k8s.io/utils v0.0.0-20200603063816-c1c6865ac451/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
+k8s.io/utils v0.0.0-20200720150651-0bdb4ca86cbc h1:GiXZzevctVRRBh56shqcqB9s9ReWMU6GTsFyE2RCFJQ=
+k8s.io/utils v0.0.0-20200720150651-0bdb4ca86cbc/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/manifests/crd-v1alpha1.yaml
+++ b/manifests/crd-v1alpha1.yaml
@@ -2,9 +2,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: noderesourcetopologies.k8s.cncf.io
+  name: noderesourcetopologies.topology.node.k8s.io
 spec:
-  group: k8s.cncf.io
+  group: topology.node.k8s.io
   version: v1alpha1
   versions:
     - name: v1alpha1

--- a/manifests/resource-topology-exporter-ds.yaml
+++ b/manifests/resource-topology-exporter-ds.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   name: rte-handler
 rules:
-- apiGroups: ["k8s.cncf.io"]
+- apiGroups: ["topology.node.k8s.io"]
   resources: ["noderesourcetopologies"]
   verbs: ["*"]
 - apiGroups: [""]

--- a/manifests/test-sriov-pod.yaml
+++ b/manifests/test-sriov-pod.yaml
@@ -4,19 +4,20 @@ metadata:
   name: sample-pod
   namespace: rte
   annotations:
-    k8s.v1.cni.cncf.io/networks: worker-node,worker-node,worker-node,worker-node, worker-node 
+    k8s.v1.cni.cncf.io/networks: worker-node,worker-node,worker-node,worker-node, worker-node
 spec:
+  nodeName: cnfd0-worker-0.fci1.kni.lab.eng.bos.redhat.com
   containers:
   - name: sample-container
-    image: centos 
+    image: centos
     imagePullPolicy: IfNotPresent
     command: ["sleep", "infinity"]
     resources:
       requests:
         openshift.io/sriov: 5 
-        cpu: 5 
+        cpu: 5
         memory: 200Mi
       limits:
         openshift.io/sriov: 5
-        cpu: 5 
+        cpu: 5
         memory: 200Mi

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -48,7 +48,7 @@ func NewExporter(tmPolicy string) (*CRDExporter, error) {
 func (e *CRDExporter) CreateOrUpdate(namespace string, resources []v1alpha1.NUMANodeResource) error {
 	log.Printf("Exporter Update called NodeResources is: %+v", resources)
 
-	nrt, err := e.cli.K8sV1alpha1().NodeResourceTopologies(namespace).Get(context.TODO(), e.hostname, metav1.GetOptions{})
+	nrt, err := e.cli.TopologyV1alpha1().NodeResourceTopologies(namespace).Get(context.TODO(), e.hostname, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		nrtNew := v1alpha1.NodeResourceTopology{
 			ObjectMeta: metav1.ObjectMeta{
@@ -58,7 +58,7 @@ func (e *CRDExporter) CreateOrUpdate(namespace string, resources []v1alpha1.NUMA
 			TopologyPolicy: e.topologyManagerPolicy,
 		}
 
-		nrtCreated, err := e.cli.K8sV1alpha1().NodeResourceTopologies(namespace).Create(context.TODO(), &nrtNew, metav1.CreateOptions{})
+		nrtCreated, err := e.cli.TopologyV1alpha1().NodeResourceTopologies(namespace).Create(context.TODO(), &nrtNew, metav1.CreateOptions{})
 		if err != nil {
 			return fmt.Errorf("Failed to create v1alpha1.NodeResourceTopology!:%v", err)
 		}
@@ -73,7 +73,7 @@ func (e *CRDExporter) CreateOrUpdate(namespace string, resources []v1alpha1.NUMA
 	nrtMutated := nrt.DeepCopy()
 	nrtMutated.Nodes = resources
 
-	nrtUpdated, err := e.cli.K8sV1alpha1().NodeResourceTopologies(namespace).Update(context.TODO(), nrtMutated, metav1.UpdateOptions{})
+	nrtUpdated, err := e.cli.TopologyV1alpha1().NodeResourceTopologies(namespace).Update(context.TODO(), nrtMutated, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("Failed to update v1alpha1.NodeResourceTopology!:%v", err)
 	}


### PR DESCRIPTION
     - Due to change of APIGroup from k8s.cncf.io to topology.node.k8s.io in topologyapi
       (https://github.com/swatisehgal/topologyapi/commit/6f9c5ac0d35769199f887eef954b0f6cc47595a6)
       to obtain the client we need to call TopologyV1alpha1() instead of K8sV1alpha1() in exporter.go
     - Updates made to the CRD spec to reflect the above APIGroup changes

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>